### PR TITLE
Scenario generator for extended set of NPIs

### DIFF
--- a/covid_xprize/validation/scenario_generator.ipynb
+++ b/covid_xprize/validation/scenario_generator.ipynb
@@ -41,7 +41,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "LATEST_DATA_URL = \"https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv\"\n",
     "GEO_FILE = \"../../countries_regions.csv\"\n",
     "latest_df = load_dataset(LATEST_DATA_URL, GEO_FILE)"
    ]
@@ -182,6 +182,113 @@
    "outputs": [],
    "source": [
     "scenario_df.CountryName.unique()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scenario_df.tail()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Save"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write to a file\n",
+    "# hist_file_name = \"data/future_ip.csv\"\n",
+    "# scenario_df.to_csv(hist_file_name, index=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Scenario: specific set of NPIs, freeze"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Generate"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "MAX_NPIS_DICT = {\n",
+    "    \"C1_School closing\": 3,\n",
+    "    \"C2_Workplace closing\": 3,\n",
+    "    \"C3_Cancel public events\": 2,\n",
+    "    \"C4_Restrictions on gatherings\": 4,\n",
+    "    \"C5_Close public transport\": 2,\n",
+    "    \"C6_Stay at home requirements\": 3,\n",
+    "    \"C7_Restrictions on internal movement\": 2,\n",
+    "    \"C8_International travel controls\": 4,\n",
+    "    \"E1_Income support\": 2,\n",
+    "    \"E2_Debt/contract relief\": 2,\n",
+    "    \"E3_Fiscal measures\": 1957600000000.00000,  # Max from file\n",
+    "    \"E4_International support\": 834353051822.00000,  # Max from file\n",
+    "    \"H1_Public information campaigns\": 2,\n",
+    "    \"H2_Testing policy\": 3,\n",
+    "    \"H3_Contact tracing\": 2,\n",
+    "    \"H4_Emergency investment in healthcare\": 242400000000.00000,  # Max from file\n",
+    "    \"H5_Investment in vaccines\": 100404615615.00000,  # Max from file\n",
+    "    \"H6_Facial Coverings\": 4,\n",
+    "    \"H7_Vaccination policy\": 5,\n",
+    "    \"H8_Protection of elderly people\": 3,\n",
+    "    # \"M1_Wildcard\": \"text\",  # Contains text\n",
+    "    \"V1_Vaccine Prioritisation (summary)\": 2,\n",
+    "    \"V2A_Vaccine Availability (summary)\": 3,\n",
+    "    # \"V2B_Vaccine age eligibility/availability age floor (general population summary)\": \"0-4 yrs\",  # Lowest age group\n",
+    "    # \"V2C_Vaccine age eligibility/availability age floor (at risk summary)\": \"0-4 yrs\",  # Lowest age group\n",
+    "    \"V2D_Medically/ clinically vulnerable (Non-elderly)\": 3,\n",
+    "    \"V2E_Education\": 2,\n",
+    "    \"V2F_Frontline workers  (non healthcare)\": 2,\n",
+    "    \"V2G_Frontline workers  (healthcare)\": 2,\n",
+    "    \"V3_Vaccine Financial Support (summary)\": 5,\n",
+    "    \"V4_Mandatory Vaccination (summary)\": 1\n",
+    "}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "start_date_str = \"2020-03-31\"\n",
+    "end_date_str = \"2020-06-30\"\n",
+    "countries = [\"India\", \"Mexico\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scenario_df = generate_scenario(start_date_str,\n",
+    "                                end_date_str,\n",
+    "                                latest_df,\n",
+    "                                countries,\n",
+    "                                scenario=\"Freeze\",\n",
+    "                                max_npis_dict=MAX_NPIS_DICT)"
    ]
   },
   {
@@ -525,7 +632,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -539,7 +646,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/covid_xprize/validation/scenario_generator.py
+++ b/covid_xprize/validation/scenario_generator.py
@@ -158,7 +158,7 @@ def generate_scenario(start_date_str, end_date_str, raw_df, countries=None, scen
                                       (ips_df.Date.isin(replaced_dates)) == True]
                 ips_df.drop(rows_to_drop.index, axis=0, inplace=True)
                 # Append the new rows
-                ips_df = ips_df.append(new_rows_df)
+                ips_df = pd.concat([ips_df, new_rows_df])
                 # Sort
                 ips_df.sort_values(by=ID_COLS, inplace=True)
 

--- a/covid_xprize/validation/scenario_generator.py
+++ b/covid_xprize/validation/scenario_generator.py
@@ -17,7 +17,8 @@ logging.basicConfig(
 LOGGER = logging.getLogger('scenario_generator')
 
 # See https://github.com/OxCGRT/covid-policy-tracker
-DATA_URL = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
+DATA_URL =\
+    "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv"
 ID_COLS = ['CountryName',
            'RegionName',
            'Date']
@@ -58,7 +59,7 @@ def get_raw_data(cache_file, latest=True):
                             encoding="ISO-8859-1",
                             dtype={"RegionName": str,
                                    "RegionCode": str},
-                            error_bad_lines=False)
+                            on_bad_lines='skip')
     latest_df["RegionName"] = latest_df["RegionName"].fillna("")
     # Fill any missing NPIs by assuming they are the same as previous day, or 0 if none is available
     latest_df.update(latest_df.groupby(['CountryName', 'RegionName'])[NPI_COLUMNS].ffill().fillna(0))

--- a/covid_xprize/validation/tests/test_scenario_generator.py
+++ b/covid_xprize/validation/tests/test_scenario_generator.py
@@ -64,8 +64,8 @@ class TestScenarioGenerator(unittest.TestCase):
         self._check_counterfactual("MAX", MAX_NPIS)
 
     def test_generate_scenario_counterfactual_custom(self):
-        # Simulate Italy used custom NPIs for a period: each NPI set to 1 for 7 consecutive days
-        scenario = [ONE_NPIS] * 7
+        # Simulate Italy used custom NPIs for a period: each NPI set to 1 for 34 consecutive days
+        scenario = [ONE_NPIS] * 34
         self._check_counterfactual(scenario, scenario[0])
 
     def _check_counterfactual(self, scenario, scenario_npis):

--- a/covid_xprize/validation/tests/test_scenario_generator.py
+++ b/covid_xprize/validation/tests/test_scenario_generator.py
@@ -7,7 +7,7 @@ import unittest
 import numpy as np
 import pandas as pd
 
-from covid_xprize.validation.scenario_generator import NPI_COLUMNS, get_raw_data, MIN_NPIS, MAX_NPIS, generate_scenario
+from covid_xprize.validation.scenario_generator import get_raw_data, generate_scenario
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_PATH = os.path.join(ROOT_DIR, 'fixtures')
@@ -15,6 +15,43 @@ DATA_FILE = os.path.join(FIXTURES_PATH, "OxCGRT_latest.csv")
 # This file contains data for Belgium and Brazil, where Brazil has 1 more day of data than Belgium
 DATES_MISMATCH_DATA_FILE = os.path.join(FIXTURES_PATH, "OxCGRT_dates_mismatch.csv")
 
+MAX_NPIS_DICT = {
+    "C1_School closing": 3,
+    "C2_Workplace closing": 3,
+    "C3_Cancel public events": 2,
+    "C4_Restrictions on gatherings": 4,
+    "C5_Close public transport": 2,
+    "C6_Stay at home requirements": 3,
+    "C7_Restrictions on internal movement": 2,
+    "C8_International travel controls": 4,
+    "E1_Income support": 2,
+    "E2_Debt/contract relief": 2,
+    "E3_Fiscal measures": 1957600000000.00000,  # Max from file
+    "E4_International support": 834353051822.00000,  # Max from file
+    "H1_Public information campaigns": 2,
+    "H2_Testing policy": 3,
+    "H3_Contact tracing": 2,
+    "H4_Emergency investment in healthcare": 242400000000.00000,  # Max from file
+    "H5_Investment in vaccines": 100404615615.00000,  # Max from file
+    "H6_Facial Coverings": 4,
+    "H7_Vaccination policy": 5,
+    "H8_Protection of elderly people": 3,
+    # "M1_Wildcard": "text",  # Contains text
+    "V1_Vaccine Prioritisation (summary)": 2,
+    "V2A_Vaccine Availability (summary)": 3,
+    # "V2B_Vaccine age eligibility/availability age floor (general population summary)": "0-4 yrs",  # Lowest age group
+    # "V2C_Vaccine age eligibility/availability age floor (at risk summary)": "0-4 yrs",  # Lowest age group
+    "V2D_Medically/ clinically vulnerable (Non-elderly)": 3,
+    "V2E_Education": 2,
+    "V2F_Frontline workers  (non healthcare)": 2,
+    "V2G_Frontline workers  (healthcare)": 2,
+    "V3_Vaccine Financial Support (summary)": 5,
+    "V4_Mandatory Vaccination (summary)": 1
+}
+
+NPI_COLUMNS = list(MAX_NPIS_DICT.keys())
+MIN_NPIS = [0] * len(NPI_COLUMNS)
+MAX_NPIS = list(MAX_NPIS_DICT.values())
 # Sets each NPI to level 1
 ONE_NPIS = [1] * len(NPI_COLUMNS)
 
@@ -45,7 +82,7 @@ class TestScenarioGenerator(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         # Load the csv data only once
-        cls.latest_df = get_raw_data(DATA_FILE, latest=True)
+        cls.latest_df = get_raw_data(DATA_FILE, latest=True, npi_columns=NPI_COLUMNS)
 
     def test_generate_scenario_counterfactual_freeze(self):
         # Simulate Italy did not start increasing NPIs on Feb 22, but instead waited before changing them
@@ -73,7 +110,12 @@ class TestScenarioGenerator(unittest.TestCase):
         start_date_str = "2020-02-22"
         end_date_str = "2020-03-26"
         countries = ["Italy"]
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -119,7 +161,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = list(frozen_npis_df.values[0])
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -139,7 +186,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = MIN_NPIS
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -159,7 +211,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = MAX_NPIS
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -181,7 +238,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario = [ONE_NPIS] * nb_days
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
         # Check it
         self._check_future(start_date_str=start_date_str,
                            end_date_str=end_date_str,
@@ -202,7 +264,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = list(frozen_npis_df.values[0])
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -223,7 +290,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = MIN_NPIS
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -244,7 +316,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario_npis = MAX_NPIS
 
         # Generate the scenario
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=start_date_str,
@@ -265,7 +342,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario = [ONE_NPIS] * nb_days
 
         # Generate the scenario
-        scenario_df = generate_scenario(None, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(None,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check it
         self._check_future(start_date_str=None,
@@ -289,7 +371,12 @@ class TestScenarioGenerator(unittest.TestCase):
         scenario = [ONE_NPIS] * nb_days
 
         # Generate the scenarios
-        scenario_df = generate_scenario(None, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(None,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
 
         # Check them
         all_countries = self.latest_df.CountryName.unique()
@@ -350,7 +437,12 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = end_date.strftime(DATE_FORMAT)
         inception_date = pd.to_datetime(INCEPTION_DATE, format=DATE_FORMAT)
 
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario="Freeze")
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario="Freeze",
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -372,7 +464,12 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = end_date.strftime(DATE_FORMAT)
         inception_date = pd.to_datetime(INCEPTION_DATE, format=DATE_FORMAT)
 
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario="MIN")
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario="MIN",
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -394,7 +491,12 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = end_date.strftime(DATE_FORMAT)
         inception_date = pd.to_datetime(INCEPTION_DATE, format=DATE_FORMAT)
 
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario="MAX")
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario="MAX",
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -419,7 +521,12 @@ class TestScenarioGenerator(unittest.TestCase):
 
         # Set all the NPIs to one for each day between start date and end date, as well as from last known date.
         scenario = [ONE_NPIS] * (nb_days + start_lag)
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario=scenario,
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -442,7 +549,12 @@ class TestScenarioGenerator(unittest.TestCase):
         inception_date = pd.to_datetime(INCEPTION_DATE, format=DATE_FORMAT)
 
         countries = ["France", "Italy"]
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario="Freeze")
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario="Freeze",
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")
@@ -459,7 +571,12 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = end_date.strftime(DATE_FORMAT)
         inception_date = datetime.strptime(INCEPTION_DATE, DATE_FORMAT)
         countries = None
-        scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario="Freeze")
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        self.latest_df,
+                                        countries,
+                                        scenario="Freeze",
+                                        max_npis_dict=MAX_NPIS_DICT)
         self.assertIsNotNone(scenario_df)
         nb_days_since_inception = (end_date - inception_date).days + 1
         # For each country, assert the scenario contains the expected number of days
@@ -481,7 +598,12 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = "2021-01-31"
         countries = ["Belgium", "Brazil"]
         dates_mismatch_df = get_raw_data(DATES_MISMATCH_DATA_FILE, latest=False)
-        scenario_df = generate_scenario(start_date_str, end_date_str, dates_mismatch_df, countries, scenario="Freeze")
+        # Not specifying NPIs: can only test the 'default' NPIs that are in DATES_MISMATCH_DATA_FILE
+        scenario_df = generate_scenario(start_date_str,
+                                        end_date_str,
+                                        dates_mismatch_df,
+                                        countries,
+                                        scenario="Freeze")
         self.assertIsNotNone(scenario_df)
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual(countries, scenario_df.CountryName.unique(), "Not the requested countries")

--- a/covid_xprize/validation/tests/test_scenario_generator.py
+++ b/covid_xprize/validation/tests/test_scenario_generator.py
@@ -48,8 +48,8 @@ class TestScenarioGenerator(unittest.TestCase):
         cls.latest_df = get_raw_data(DATA_FILE, latest=True)
 
     def test_generate_scenario_counterfactual_freeze(self):
-        # Simulate Italy did not enter full lockdown on Mar 20, but instead waited 1 week before changing its NPIs
-        before_day = pd.to_datetime("2020-03-19", format=DATE_FORMAT)
+        # Simulate Italy did not start increasing NPIs on Feb 22, but instead waited before changing them
+        before_day = pd.to_datetime("2020-02-21", format=DATE_FORMAT)
         frozen_npis_df = self.latest_df[(self.latest_df.CountryName == "Italy") &
                                         (self.latest_df.Date == before_day)][NPI_COLUMNS].reset_index(drop=True)
         frozen_npis = list(frozen_npis_df.values[0])
@@ -69,8 +69,8 @@ class TestScenarioGenerator(unittest.TestCase):
         self._check_counterfactual(scenario, scenario[0])
 
     def _check_counterfactual(self, scenario, scenario_npis):
-        # Simulate Italy lifted all NPI for this period
-        start_date_str = "2020-03-20"
+        # Simulate Italy applied the passed NPIs for this period
+        start_date_str = "2020-02-22"
         end_date_str = "2020-03-26"
         countries = ["Italy"]
         scenario_df = generate_scenario(start_date_str, end_date_str, self.latest_df, countries, scenario=scenario)

--- a/covid_xprize/validation/tests/test_scenario_generator.py
+++ b/covid_xprize/validation/tests/test_scenario_generator.py
@@ -283,7 +283,9 @@ class TestScenarioGenerator(unittest.TestCase):
         end_date_str = (last_known_date + pd.DateOffset(7)).strftime(DATE_FORMAT)
 
         # Make sure we generate scenarios for enough days
-        nb_days = 14
+        official_end_date_str = "2022-12-01"
+        official_end_date = pd.to_datetime(official_end_date_str, format=DATE_FORMAT)
+        nb_days = (last_known_date - official_end_date).days
         scenario = [ONE_NPIS] * nb_days
 
         # Generate the scenarios
@@ -307,7 +309,6 @@ class TestScenarioGenerator(unittest.TestCase):
         # Misleading name but checks the elements, regardless of order
         self.assertCountEqual([country], scenario_df.CountryName.unique(), "Not the expected country")
         self.assertCountEqual([region], scenario_df.RegionName.unique(), "Not the requested region")
-        self.assertFalse(scenario_df["Date"].duplicated().any(), "Did not expect duplicated days")
         self.assertFalse(scenario_df["Date"].duplicated().any(), "Expected 1 row per date only")
         end_date = pd.to_datetime(end_date_str, format=DATE_FORMAT)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,18 +1,18 @@
 # Copyright 2020 (c) Cognizant Digital Business, Evolutionary AI. All rights reserved. Issued under the Apache 2.0 License.
 # data science
-pandas==1.1.2
-numpy==1.18.5
-notebook==6.1.5
-scikit-learn==0.23.2
-scipy==1.5.2
-tensorflow==2.2.2
-keras==2.4.3
+pandas==1.4.2
+numpy==1.23.5
+notebook==6.5.2
+scikit-learn==1.1.1
+scipy==1.10.0
+tensorflow==2.10.0
+keras==2.10.0
 neat-python==0.92
-h5py==2.10.0
+h5py==3.7.0
 
 # plotting
 plotly==4.11.0
-matplotlib==3.3.2
+matplotlib==3.6.2
 
 # tests
 pytest==6.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,19 +1,15 @@
 # Copyright 2020 (c) Cognizant Digital Business, Evolutionary AI. All rights reserved. Issued under the Apache 2.0 License.
 # data science
-pandas==1.4.2
-numpy==1.23.5
-notebook==6.5.2
-scikit-learn==1.1.1
-scipy==1.10.0
-tensorflow==2.10.0
-keras==2.10.0
+pandas==1.5.3
+numpy==1.24.2
+notebook==6.5.3
+scikit-learn==1.2.2
+scipy==1.10.1
+tensorflow==2.11.1
+keras==2.12.0
 neat-python==0.92
-h5py==3.7.0
+h5py==3.8.0
 
 # plotting
-plotly==4.11.0
-matplotlib==3.6.2
-
-# tests
-pytest==6.1.1
-nose==1.3.7
+plotly==5.13.1
+matplotlib==3.7.1

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-LIBRARY_VERSION = '1.1.7'
+LIBRARY_VERSION = '2.0.0'
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 6)
@@ -60,15 +60,15 @@ setup(
         ]
     },
     install_requires=[
-        'keras==2.4.3',
+        'keras==2.10.0',
         'neat-python==0.92',
-        'numpy==1.18.5',
-        'pandas==1.1.2',
-        'scikit-learn==0.23.2',
-        'scipy==1.5.2',
+        'numpy==1.23.5',
+        'pandas==1.4.2',
+        'scikit-learn==1.1.1',
+        'scipy==1.10.0',
         'setuptools==41.0.0',
-        'tensorflow==2.2.2',
-        'h5py==2.10.0'
+        'tensorflow==2.10.0',
+        'h5py==3.7.0'
     ],
     description='Contains sample code and notebooks '
                 'for developing and validating entries for the Cognizant COVID X-Prize.',

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ from setuptools import setup, find_packages
 LIBRARY_VERSION = '2.0.0'
 
 CURRENT_PYTHON = sys.version_info[:2]
-REQUIRED_PYTHON = (3, 6)
+REQUIRED_PYTHON = (3, 10)
 
 if CURRENT_PYTHON < REQUIRED_PYTHON:
     sys.stderr.write('''
@@ -60,15 +60,15 @@ setup(
         ]
     },
     install_requires=[
-        'keras==2.10.0',
+        'keras==2.12.0',
         'neat-python==0.92',
-        'numpy==1.23.5',
-        'pandas==1.4.2',
-        'scikit-learn==1.1.1',
-        'scipy==1.10.0',
-        'setuptools==41.0.0',
-        'tensorflow==2.10.0',
-        'h5py==3.7.0'
+        'numpy==1.24.2',
+        'pandas==1.5.3',
+        'scikit-learn==1.2.2',
+        'scipy==1.10.1',
+        'setuptools==67.6.0',
+        'tensorflow==2.11.1',
+        'h5py==3.8.0'
     ],
     description='Contains sample code and notebooks '
                 'for developing and validating entries for the Cognizant COVID X-Prize.',


### PR DESCRIPTION
Oxford Covid-19 Government Response Tracker has stopped updating Covid19 data. The data file this project uses is now "legacy" bit it's being cleaned up to include accurate data from 2020-01-01 to 2022-12-31. It also includes more NPIs that were not available at the time this project was developed.

This PR:
- updates the link to the `OxCGRT_latest.csv` file
- updates a few project dependencies
- fixes the scenario generator tests
- adds support for specific sets of NPIs in scenario_generator.py
- and generates a scenario for most available NPIs in the scenario generator notebook