### PR TITLE
Fix Pandas append deprecation warnings

### DIFF
--- a/covid_xprize/examples/predictors/lstm/tests/test_xprize_predictor.py
+++ b/covid_xprize/examples/predictors/lstm/tests/test_xprize_predictor.py
@@ -12,7 +12,8 @@ ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 FIXTURES_PATH = os.path.join(ROOT_DIR, 'fixtures')
 EXAMPLE_INPUT_FILE = os.path.join(ROOT_DIR, "../../../../validation/data/2020-09-30_historical_ip.csv")
 DATA_FILE = os.path.join(FIXTURES_PATH, "OxCGRT_latest.csv")
-DATA_URL = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
+DATA_URL =\
+    "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv"
 PREDICTOR_WEIGHTS = os.path.join(FIXTURES_PATH, "trained_model_weights_for_tests.h5")
 
 START_DATE = "2020-08-01"

--- a/covid_xprize/examples/predictors/lstm/xprize_predictor.py
+++ b/covid_xprize/examples/predictors/lstm/xprize_predictor.py
@@ -19,7 +19,8 @@ from keras.layers import Lambda
 from keras.models import Model
 
 # See https://github.com/OxCGRT/covid-policy-tracker
-DATA_URL = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
+DATA_URL =\
+    "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv"
 
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_PATH = os.path.join(ROOT_DIR, 'data')
@@ -271,18 +272,17 @@ class XPrizePredictor(object):
         # Prefix with country name to match measures_df
         additional_us_states_df['GeoID'] = US_PREFIX + additional_us_states_df['NAME']
 
-        # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_us_states_df)
-
         # UK population
         additional_uk_df = pd.read_csv(ADDITIONAL_UK_CONTEXT)
-        # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_uk_df)
 
         # Brazil population
         additional_brazil_df = pd.read_csv(ADDITIONAL_BRAZIL_CONTEXT)
+
         # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_brazil_df)
+        additional_context_df = pd.concat([additional_context_df,
+                                           additional_us_states_df,
+                                           additional_uk_df,
+                                           additional_brazil_df])
 
         return additional_context_df
 

--- a/covid_xprize/scoring/prescriptor_scoring.py
+++ b/covid_xprize/scoring/prescriptor_scoring.py
@@ -33,7 +33,7 @@ def generate_cases_and_stringency_for_prescriptions(start_date, end_date, prescr
         if past_ips_file:
             past_ips_df = XPrizePredictor.load_original_data(past_ips_file)
             past_ips_df = past_ips_df[past_ips_df['Date'] < start_date]
-            idx_df = past_ips_df.append(idx_df)
+            idx_df = pd.concat([past_ips_df, idx_df])
 
         # Generate the predictions
         pred_df = predictor.predict_from_df(start_date, end_date, idx_df)

--- a/covid_xprize/standard_predictor/xprize_predictor.py
+++ b/covid_xprize/standard_predictor/xprize_predictor.py
@@ -278,18 +278,17 @@ class XPrizePredictor(object):
         # Prefix with country name to match measures_df
         additional_us_states_df['GeoID'] = US_PREFIX + additional_us_states_df['NAME']
 
-        # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_us_states_df)
-
         # UK population
         additional_uk_df = pd.read_csv(ADDITIONAL_UK_CONTEXT)
-        # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_uk_df)
 
         # Brazil population
         additional_brazil_df = pd.read_csv(ADDITIONAL_BRAZIL_CONTEXT)
+
         # Append the new data to additional_df
-        additional_context_df = additional_context_df.append(additional_brazil_df)
+        additional_context_df = pd.concat([additional_context_df,
+                                           additional_us_states_df,
+                                           additional_uk_df,
+                                           additional_brazil_df])
 
         return additional_context_df
 

--- a/predictor_robojudge.ipynb
+++ b/predictor_robojudge.ipynb
@@ -31,8 +31,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
-    "GEO_FILE = \"countries_regions.csv\""
+    "LATEST_DATA_URL = \"https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv\"\n",
+    "GEO_FILE = \"countries_regions.csv\"\n"
    ]
   },
   {
@@ -216,7 +216,7 @@
     "if new_rows:\n",
     "    new_rows_df = pd.DataFrame(new_rows, columns=actual_df.columns)\n",
     "    # Append the new rows\n",
-    "    actual_df = actual_df.append(new_rows_df)\n",
+    "    actual_df = pd.concat([actual_df, new_rows_df])\n",
     "# Sort\n",
     "actual_df.sort_values(by=ID_COLS, inplace=True, ignore_index=True)"
    ]
@@ -266,6 +266,8 @@
    "outputs": [],
    "source": [
     "IP_FILE = \"predictions/robojudge_test_scenario.csv\"\n",
+    "if not os.path.exists('predictions'):\n",
+    "    os.mkdir('predictions')\n",
     "predictions = {}"
    ]
   },
@@ -397,7 +399,7 @@
     "    # Append the true number of cases before start date\n",
     "    ma_df[\"PredictorName\"] = predictor_name\n",
     "    ma_df[\"Prediction\"] = False\n",
-    "    preds_df = ma_df.append(preds_df, ignore_index=True)\n",
+    "    preds_df = pd.concat([ma_df, preds_df], ignore_index=True)\n",
     "\n",
     "    # Add GeoID column that combines CountryName and RegionName for easier manipulation of data\n",
     "    # np.where usage: if A then B else C\n",
@@ -451,7 +453,7 @@
     "    if not errors:\n",
     "        preds_df = get_predictions_from_file(predictor_name, predictions_file, ma_df)\n",
     "        merged_df = actual_df.merge(preds_df, on=['CountryName', 'RegionName', 'Date', 'GeoID'], how='left')\n",
-    "        ranking_df = ranking_df.append(merged_df)\n",
+    "        ranking_df = pd.concat([ranking_df, merged_df])\n",
     "    else:\n",
     "        print(f\"Predictor {predictor_name} did not submit valid predictions! Please check its errors:\")\n",
     "        print(errors)"
@@ -805,9 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "ranking_fig = go.Figure(layout=dict(title=dict(text=f'{DEFAULT_GEO} submission rankings',\n",
@@ -883,7 +883,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -897,7 +897,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.10.8"
   },
   "pycharm": {
    "stem_cell": {


### PR DESCRIPTION
Replaced deprecated Pandas DataFrame.append() by pd.concat()

According to https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.append.html:
```
Deprecated since version 1.4.0: Use [concat()](https://pandas.pydata.org/docs/reference/api/pandas.concat.html#pandas.concat) instead. For further details see [Deprecated DataFrame.append and Series.append](https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#whatsnew-140-deprecations-frame-series-append)
```