### PR TITLE
Fix Pandas groupby FutureWarnings

### DIFF
--- a/covid_xprize/examples/predictors/linear/Example-Train-Linear-Rollout-Model.ipynb
+++ b/covid_xprize/examples/predictors/linear/Example-Train-Linear-Rollout-Model.ipynb
@@ -57,9 +57,9 @@
    "outputs": [],
    "source": [
     "# Main source for the training data\n",
-    "DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "DATA_URL = \"https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv\"\n",
     "# Local file\n",
-    "DATA_FILE = 'data/OxCGRT_latest.csv'"
+    "DATA_FILE = 'data/OxCGRT_latest.csv'\n"
    ]
   },
   {
@@ -127,7 +127,7 @@
    "outputs": [],
    "source": [
     "# Add new cases column\n",
-    "df['NewCases'] = df.groupby('GeoID').ConfirmedCases.diff().fillna(0)"
+    "df['NewCases'] = df.groupby('GeoID', group_keys=False).ConfirmedCases.diff().fillna(0)"
    ]
   },
   {
@@ -164,7 +164,7 @@
    "outputs": [],
    "source": [
     "# Fill any missing case values by interpolation and setting NaNs to 0\n",
-    "df.update(df.groupby('GeoID').NewCases.apply(\n",
+    "df.update(df.groupby('GeoID', group_keys=False).NewCases.apply(\n",
     "    lambda group: group.interpolate()).fillna(0))"
    ]
   },
@@ -176,7 +176,7 @@
    "source": [
     "# Fill any missing NPIs by assuming they are the same as previous day\n",
     "for npi_col in npi_cols:\n",
-    "    df.update(df.groupby('GeoID')[npi_col].ffill().fillna(0))"
+    "    df.update(df.groupby('GeoID', group_keys=False)[npi_col].ffill().fillna(0))"
    ]
   },
   {
@@ -556,7 +556,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -570,7 +570,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.10.8"
   },
   "pycharm": {
    "stem_cell": {

--- a/covid_xprize/examples/predictors/linear/predict.py
+++ b/covid_xprize/examples/predictors/linear/predict.py
@@ -81,7 +81,8 @@ def predict_df(start_date_str: str, end_date_str: str, path_to_ips_file: str, ve
     hist_ips_df['GeoID'] = hist_ips_df['CountryName'] + '__' + hist_ips_df['RegionName'].astype(str)
     # Fill any missing NPIs by assuming they are the same as previous day
     for npi_col in NPI_COLS:
-        hist_ips_df.update(hist_ips_df.groupby(['CountryName', 'RegionName'])[npi_col].ffill().fillna(0))
+        hist_ips_df.update(hist_ips_df.groupby(['CountryName', 'RegionName'],
+                                               group_keys=False)[npi_col].ffill().fillna(0))
 
     # Intervention plans to forecast for: those between start_date and end_date
     ips_df = hist_ips_df[(hist_ips_df.Date >= start_date) & (hist_ips_df.Date <= end_date)]
@@ -98,9 +99,9 @@ def predict_df(start_date_str: str, end_date_str: str, path_to_ips_file: str, ve
     # Add RegionID column that combines CountryName and RegionName for easier manipulation of data
     hist_cases_df['GeoID'] = hist_cases_df['CountryName'] + '__' + hist_cases_df['RegionName'].astype(str)
     # Add new cases column
-    hist_cases_df['NewCases'] = hist_cases_df.groupby('GeoID').ConfirmedCases.diff().fillna(0)
+    hist_cases_df['NewCases'] = hist_cases_df.groupby('GeoID', group_keys=False).ConfirmedCases.diff().fillna(0)
     # Fill any missing case values by interpolation and setting NaNs to 0
-    hist_cases_df.update(hist_cases_df.groupby('GeoID').NewCases.apply(
+    hist_cases_df.update(hist_cases_df.groupby('GeoID', group_keys=False).NewCases.apply(
         lambda group: group.interpolate()).fillna(0))
     # Keep only the id and cases columns
     hist_cases_df = hist_cases_df[ID_COLS + CASES_COL]

--- a/covid_xprize/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
+++ b/covid_xprize/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
@@ -158,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "DATA_URL = \"https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv\"\n",
     "df = pd.read_csv(DATA_URL,\n",
     "                 parse_dates=['Date'],\n",
     "                 encoding=\"ISO-8859-1\",\n",
@@ -190,7 +190,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"DailyChangeConfirmedCases\"] = df.groupby([\"CountryName\", \"RegionName\"]).ConfirmedCases.diff().fillna(0)"
+    "df[\"DailyChangeConfirmedCases\"] = df.groupby([\"CountryName\", \"RegionName\"], group_keys=False).ConfirmedCases.diff().fillna(0)"
    ]
   },
   {
@@ -562,7 +562,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -576,7 +576,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.2"
+   "version": "3.10.8"
   },
   "pycharm": {
    "stem_cell": {

--- a/covid_xprize/examples/predictors/lstm/xprize_predictor.py
+++ b/covid_xprize/examples/predictors/lstm/xprize_predictor.py
@@ -197,23 +197,23 @@ class XPrizePredictor(object):
         self._fill_missing_values(df)
 
         # Compute number of new cases and deaths each day
-        df['NewCases'] = df.groupby('GeoID').ConfirmedCases.diff().fillna(0)
-        df['NewDeaths'] = df.groupby('GeoID').ConfirmedDeaths.diff().fillna(0)
+        df['NewCases'] = df.groupby('GeoID', group_keys=False).ConfirmedCases.diff().fillna(0)
+        df['NewDeaths'] = df.groupby('GeoID', group_keys=False).ConfirmedDeaths.diff().fillna(0)
 
         # Replace negative values (which do not make sense for these columns) with 0
         df['NewCases'] = df['NewCases'].clip(lower=0)
         df['NewDeaths'] = df['NewDeaths'].clip(lower=0)
 
         # Compute smoothed versions of new cases and deaths each day
-        df['SmoothNewCases'] = df.groupby('GeoID')['NewCases'].rolling(
+        df['SmoothNewCases'] = df.groupby('GeoID', group_keys=False)['NewCases'].rolling(
             WINDOW_SIZE, center=False).mean().fillna(0).reset_index(0, drop=True)
-        df['SmoothNewDeaths'] = df.groupby('GeoID')['NewDeaths'].rolling(
+        df['SmoothNewDeaths'] = df.groupby('GeoID', group_keys=False)['NewDeaths'].rolling(
             WINDOW_SIZE, center=False).mean().fillna(0).reset_index(0, drop=True)
 
         # Compute percent change in new cases and deaths each day
-        df['CaseRatio'] = df.groupby('GeoID').SmoothNewCases.pct_change(
+        df['CaseRatio'] = df.groupby('GeoID', group_keys=False).SmoothNewCases.pct_change(
         ).fillna(0).replace(np.inf, 0) + 1
-        df['DeathRatio'] = df.groupby('GeoID').SmoothNewDeaths.pct_change(
+        df['DeathRatio'] = df.groupby('GeoID', group_keys=False).SmoothNewDeaths.pct_change(
         ).fillna(0).replace(np.inf, 0) + 1
 
         # Add column for proportion of population infected
@@ -245,16 +245,16 @@ class XPrizePredictor(object):
         # Fill missing values by interpolation, ffill, and filling NaNs
         :param df: Dataframe to be filled
         """
-        df.update(df.groupby('GeoID').ConfirmedCases.apply(
+        df.update(df.groupby('GeoID', group_keys=False).ConfirmedCases.apply(
             lambda group: group.interpolate(limit_area='inside')))
         # Drop country / regions for which no number of cases is available
         df.dropna(subset=['ConfirmedCases'], inplace=True)
-        df.update(df.groupby('GeoID').ConfirmedDeaths.apply(
+        df.update(df.groupby('GeoID', group_keys=False).ConfirmedDeaths.apply(
             lambda group: group.interpolate(limit_area='inside')))
         # Drop country / regions for which no number of deaths is available
         df.dropna(subset=['ConfirmedDeaths'], inplace=True)
         for npi_column in NPI_COLUMNS:
-            df.update(df.groupby('GeoID')[npi_column].ffill().fillna(0))
+            df.update(df.groupby('GeoID', group_keys=False)[npi_column].ffill().fillna(0))
 
     @staticmethod
     def _load_additional_context_df():
@@ -487,7 +487,8 @@ class XPrizePredictor(object):
         country names that have at least min_look_back_days data points.
         """
         # By default use most affected geos with enough history
-        gdf = df.groupby('GeoID')['ConfirmedDeaths'].agg(['max', 'count']).sort_values(by='max', ascending=False)
+        gdf = df.groupby('GeoID', group_keys=False)['ConfirmedDeaths'].agg(['max', 'count']).sort_values(
+            by='max', ascending=False)
         filtered_gdf = gdf[gdf["count"] > min_historical_days]
         geos = list(filtered_gdf.head(nb_geos).index)
         return geos

--- a/covid_xprize/examples/prescriptors/neat/train_prescriptor.py
+++ b/covid_xprize/examples/prescriptors/neat/train_prescriptor.py
@@ -56,7 +56,7 @@ df = df[df['Date'] <= cutoff_date]
 
 # As a heuristic, use the top NB_EVAL_COUNTRIES w.r.t. ConfirmedCases
 # so far as the geos for evaluation.
-eval_geos = list(df.groupby('GeoID').max()['ConfirmedCases'].sort_values(
+eval_geos = list(df.groupby('GeoID', group_keys=False).max()['ConfirmedCases'].sort_values(
                 ascending=False).head(NB_EVAL_COUNTRIES).index)
 print("Nets will be evaluated on the following geos:", eval_geos)
 

--- a/covid_xprize/examples/prescriptors/neat/utils.py
+++ b/covid_xprize/examples/prescriptors/neat/utils.py
@@ -81,15 +81,15 @@ def prepare_historical_df():
     df = add_geo_id(df)
 
     # Add new cases column
-    df['NewCases'] = df.groupby('GeoID').ConfirmedCases.diff().fillna(0)
+    df['NewCases'] = df.groupby('GeoID', group_keys=False).ConfirmedCases.diff().fillna(0)
 
     # Fill any missing case values by interpolation and setting NaNs to 0
-    df.update(df.groupby('GeoID').NewCases.apply(
+    df.update(df.groupby('GeoID', group_keys=False).NewCases.apply(
         lambda group: group.interpolate()).fillna(0))
 
     # Fill any missing IPs by assuming they are the same as previous day
     for ip_col in IP_MAX_VALUES:
-        df.update(df.groupby('GeoID')[ip_col].ffill().fillna(0))
+        df.update(df.groupby('GeoID', group_keys=False)[ip_col].ffill().fillna(0))
 
     return df
 

--- a/covid_xprize/scoring/predictor_scoring.py
+++ b/covid_xprize/scoring/predictor_scoring.py
@@ -66,7 +66,7 @@ def add_predictor_performance_columns(ranking_df):
 
         # Compute the cumulative sum of 7DMA errors
         ranking_df['CumulDiff7DMA'] = ranking_df.groupby(["GeoID",
-                                                          "PredictorName"])['Diff7DMA'].cumsum()
+                                                          "PredictorName"], group_keys=False)['Diff7DMA'].cumsum()
 
         # Normalize CumulDiff7DMA by geo population size
         ranking_df['Cumul-7DMA-MAE-per-100K'] = ranking_df['CumulDiff7DMA'] / \
@@ -79,7 +79,7 @@ def add_predictor_performance_columns(ranking_df):
         # equality errors when comparing the CumulDiff7DMA of predictors that have
         # predicted the exact same number of daily cases.
         ranking_df['PredictorRank'] = ranking_df.round().groupby(
-            ["GeoID", "Date"])['CumulDiff7DMA'].rank(method='average')
+            ["GeoID", "Date"], group_keys=False)['CumulDiff7DMA'].rank(method='average')
 
         # Sort by 7 days moving average mae per 100K
         ranking_df.sort_values(by=["CountryName",

--- a/covid_xprize/scoring/prescriptor_scoring.py
+++ b/covid_xprize/scoring/prescriptor_scoring.py
@@ -45,7 +45,7 @@ def generate_cases_and_stringency_for_prescriptions(start_date, end_date, prescr
     # Aggregate cases by prescription index and geo
     agg_pred_df = pred_df.groupby(['CountryName',
                                    'RegionName',
-                                   'PrescriptionIndex'], dropna=False).mean().reset_index()
+                                   'PrescriptionIndex'], group_keys=False, dropna=False).mean().reset_index()
 
     # Load IP cost weights
     cost_df = pd.read_csv(costs_file)
@@ -63,7 +63,7 @@ def generate_cases_and_stringency_for_prescriptions(start_date, end_date, prescr
     # Aggregate stringency by prescription index and geo
     agg_pres_df = pres_df.groupby(['CountryName',
                                    'RegionName',
-                                   'PrescriptionIndex'], dropna=False).mean().reset_index()
+                                   'PrescriptionIndex'], group_keys=False, dropna=False).mean().reset_index()
 
     # Combine stringency and cases into a single df
     df = agg_pres_df.merge(agg_pred_df, how='outer', on=['CountryName',

--- a/covid_xprize/validation/scenario_generator.py
+++ b/covid_xprize/validation/scenario_generator.py
@@ -63,7 +63,7 @@ def get_raw_data(cache_file, latest=True, npi_columns=NPI_COLUMNS):
                             on_bad_lines='skip')
     latest_df["RegionName"] = latest_df["RegionName"].fillna("")
     # Fill any missing NPIs by assuming they are the same as previous day, or 0 if none is available
-    latest_df.update(latest_df.groupby(['CountryName', 'RegionName'])[npi_columns].ffill().fillna(0))
+    latest_df.update(latest_df.groupby(['CountryName', 'RegionName'], group_keys=False)[npi_columns].ffill().fillna(0))
     return latest_df
 
 
@@ -120,7 +120,7 @@ def generate_scenario(start_date_str,
 
     # Fill any missing "supposedly known" NPIs by assuming they are the same as previous day, or 0 if none is available
     for npi_col in npi_columns:
-        ips_df.update(ips_df.groupby(['CountryName', 'RegionName'])[npi_col].ffill().fillna(0))
+        ips_df.update(ips_df.groupby(['CountryName', 'RegionName'], group_keys=False)[npi_col].ffill().fillna(0))
 
     if scenario == "Historical":
         return ips_df

--- a/predictor_robojudge.ipynb
+++ b/predictor_robojudge.ipynb
@@ -138,10 +138,10 @@
     "                                  actual_df[\"CountryName\"] + ' / ' + actual_df[\"RegionName\"])\n",
     "    actual_df.sort_values(by=[\"GeoID\",\"Date\"], inplace=True)\n",
     "    # Compute the diff\n",
-    "    actual_df[\"ActualDailyNewCases\"] = actual_df.groupby(\"GeoID\")[\"ConfirmedCases\"].diff()\n",
+    "    actual_df[\"ActualDailyNewCases\"] = actual_df.groupby(\"GeoID\", group_keys=False)[\"ConfirmedCases\"].diff()\n",
     "    # Compute the 7 day moving average\n",
     "    actual_df[\"ActualDailyNewCases7DMA\"] = actual_df.groupby(\n",
-    "        \"GeoID\")['ActualDailyNewCases'].rolling(\n",
+    "        \"GeoID\", group_keys=False)['ActualDailyNewCases'].rolling(\n",
     "        WINDOW_SIZE, center=False).mean().reset_index(0, drop=True)\n",
     "    return actual_df"
    ]
@@ -410,7 +410,7 @@
     "    preds_df.sort_values(by=[\"GeoID\",\"Date\"], inplace=True)\n",
     "    # Compute the 7 days moving average for PredictedDailyNewCases\n",
     "    preds_df[\"PredictedDailyNewCases7DMA\"] = preds_df.groupby(\n",
-    "        \"GeoID\")['PredictedDailyNewCases'].rolling(\n",
+    "        \"GeoID\", group_keys=False)['PredictedDailyNewCases'].rolling(\n",
     "        WINDOW_SIZE, center=False).mean().reset_index(0, drop=True)\n",
     "\n",
     "    # Put PredictorName first\n",
@@ -546,7 +546,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "leaderboard_df.groupby([\"PredictorName\"]).mean() \\\n",
+    "leaderboard_df.groupby([\"PredictorName\"], group_keys=False).mean() \\\n",
     "    .sort_values(by=[\"Cumul-7DMA-MAE-per-100K\"]).reset_index()"
    ]
   },
@@ -632,7 +632,7 @@
    "outputs": [],
    "source": [
     "leaderboard_df[(leaderboard_df.CountryName.isin(NORTH_AMERICA)) &\n",
-    "               (leaderboard_df.RegionName == \"\")].groupby('PredictorName').mean() \\\n",
+    "               (leaderboard_df.RegionName == \"\")].groupby('PredictorName', group_keys=False).mean() \\\n",
     "    .sort_values(by=[\"Cumul-7DMA-MAE-per-100K\"]).reset_index()"
    ]
   },
@@ -693,7 +693,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"])[[\"GeoID\", \"PredictorName\", \"PredictedDailyNewCases7DMA\"]].sum(). \\\n",
+    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"], group_keys=False)[[\"GeoID\", \"PredictorName\", \"PredictedDailyNewCases7DMA\"]].sum(). \\\n",
     "    sort_values(by=[\"PredictorName\", \"Date\"]).reset_index()\n",
     "all_df"
    ]
@@ -722,7 +722,7 @@
     "# Keep track of trace visibility by geo ID name\n",
     "geoid_plot_names = []\n",
     "\n",
-    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"])[[\"GeoID\", \"PredictorName\", \"PredictedDailyNewCases7DMA\"]].sum(). \\\n",
+    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"], group_keys=False)[[\"GeoID\", \"PredictorName\", \"PredictedDailyNewCases7DMA\"]].sum(). \\\n",
     "    sort_values(by=[\"PredictorName\", \"Date\"]).reset_index()\n",
     "\n",
     "# Add 1 trace per predictor, for all geos\n",
@@ -763,7 +763,7 @@
     "    geoid_plot_names.append(geoid_name)\n",
     "    \n",
     "# Add 1 trace for the overall ground truth\n",
-    "overall_actual_df = actual_df[actual_df.Date >= start_date].groupby([\"Date\"])[[\"GeoID\", \"ActualDailyNewCases7DMA\"]].sum(). \\\n",
+    "overall_actual_df = actual_df[actual_df.Date >= start_date].groupby([\"Date\"], group_keys=False)[[\"GeoID\", \"ActualDailyNewCases7DMA\"]].sum(). \\\n",
     "    sort_values(by=[\"Date\"]).reset_index()\n",
     "overall_last_known_date = overall_actual_df[overall_actual_df.ActualDailyNewCases7DMA > 0].Date.max()\n",
     "fig.add_trace(go.Scatter(x=overall_actual_df[overall_actual_df.Date <= overall_last_known_date].Date,\n",
@@ -824,7 +824,7 @@
     "# Keep track of trace visibility by geo name\n",
     "ranking_geoid_plot_names = []\n",
     "\n",
-    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"])[[\"GeoID\", \"PredictorName\", \"Cumul-7DMA-MAE-per-100K\"]].mean(). \\\n",
+    "all_df = ranking_df.groupby([\"PredictorName\", \"Date\"], group_keys=False)[[\"GeoID\", \"PredictorName\", \"Cumul-7DMA-MAE-per-100K\"]].mean(). \\\n",
     "    sort_values(by=[\"PredictorName\", \"Date\"]).reset_index()\n",
     "\n",
     "# Add 1 trace per predictor, for all geos\n",

--- a/predictor_submission_template.ipynb
+++ b/predictor_submission_template.ipynb
@@ -155,7 +155,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "df[\"DailyChangeConfirmedCases\"] = df.groupby([\"CountryName\", \"RegionName\"]).ConfirmedCases.diff().fillna(0)"
+    "df[\"DailyChangeConfirmedCases\"] = df.groupby([\"CountryName\", \"RegionName\"], group_keys=False).ConfirmedCases.diff().fillna(0)"
    ]
   },
   {

--- a/prescriptor_robojudge.ipynb
+++ b/prescriptor_robojudge.ipynb
@@ -238,7 +238,7 @@
    "outputs": [],
    "source": [
     "# Get number of dominated prescriptions for each submission. This is the \"Domination Count\"\n",
-    "ddf.groupby('DominatingName').count().sort_values('DominatedIndex', ascending=False)['DominatedIndex']"
+    "ddf.groupby('DominatingName', group_keys=False).count().sort_values('DominatedIndex', ascending=False)['DominatedIndex']"
    ]
   },
   {
@@ -296,7 +296,7 @@
     "plt.figure(figsize=(10,8))\n",
     "for prescriptor_name in prescription_files:\n",
     "    pdf = df[df['PrescriptorName'] == prescriptor_name]\n",
-    "    overall_pdf = pdf.groupby('PrescriptionIndex').mean().reset_index()\n",
+    "    overall_pdf = pdf.groupby('PrescriptionIndex', group_keys=False).mean().reset_index()\n",
     "    plt.scatter(overall_pdf['Stringency'],\n",
     "                overall_pdf['PredictedDailyNewCases'], \n",
     "                label=prescriptor_name)\n",
@@ -347,7 +347,7 @@
     "plt.figure(figsize=(10,8))\n",
     "for prescriptor_name in prescription_files:\n",
     "    pdf = cdf[cdf['PrescriptorName'] == prescriptor_name]\n",
-    "    #overall_pdf = pdf.groupby('PrescriptionIndex').mean().reset_index()\n",
+    "    #overall_pdf = pdf.groupby('PrescriptionIndex', group_keys=False).mean().reset_index()\n",
     "    plt.scatter(pdf['Stringency'],\n",
     "                pdf['PredictedDailyNewCases'], \n",
     "                label=prescriptor_name)\n",


### PR DESCRIPTION
Fixed Pandas' groupby FutureWarning by explicitly setting `group_keys=False` to preserve the existing behavior. Warning was:
```
Not prepending group keys to the result index of transform-like apply. 
In the future, the group keys will be included in the index, regardless 
of whether the applied function returns a like-indexed object.

To preserve the previous behavior, use

        >>> .groupby(..., group_keys=False)

To adopt the future behavior and silence this warning, use

        >>> .groupby(..., group_keys=True)
```