### PR TITLE
Update URL pointing to OxCGRT_lastest.csv

### DIFF
--- a/covid_xprize/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
+++ b/covid_xprize/examples/predictors/lstm/Example-LSTM-Predictor.ipynb
@@ -149,7 +149,7 @@
     "### Evaluation\n",
     "Predictions will be evaluated on a period of 4 weeks **after** submision against the actual daily change in confirmed cases reported by the [Oxford COVID-19 Government Response Tracker (OxCGRT)](https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker).\n",
     "\n",
-    "The latest data, including the latest confirmed cases ('ConfirmedCases') can be find here: https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
+    "The latest data, including the latest confirmed cases ('ConfirmedCases') can be find here: https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv"
    ]
   },
   {
@@ -239,7 +239,7 @@
    "outputs": [],
    "source": [
     "# Main source for the training data\n",
-    "DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "DATA_URL = \"https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv\"\n",
     "DATA_FILE = 'data/OxCGRT_latest.csv'\n",
     "\n",
     "# Download the data set\n",

--- a/covid_xprize/examples/prescriptors/neat/utils.py
+++ b/covid_xprize/examples/prescriptors/neat/utils.py
@@ -10,7 +10,8 @@ from pathlib import Path
 from covid_xprize.validation.scenario_generator import get_raw_data, generate_scenario
 
 # URL for Oxford data
-DATA_URL = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"
+DATA_URL =\
+    "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv"
 
 # Path to where this script lives
 ROOT_DIR = Path(os.path.dirname(os.path.abspath(__file__)))

--- a/covid_xprize/scoring/predictor_scoring.py
+++ b/covid_xprize/scoring/predictor_scoring.py
@@ -5,7 +5,8 @@ import pandas as pd
 
 from covid_xprize.examples.predictors.lstm.xprize_predictor import XPrizePredictor
 
-LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'
+LATEST_DATA_URL = \
+    'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv'
 ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
 COUNTRIES_REGIONS_FILE = os.path.join(ROOT_DIR, "..", "..", "countries_regions.csv")
 

--- a/covid_xprize/validation/scenario_generator.ipynb
+++ b/covid_xprize/validation/scenario_generator.ipynb
@@ -402,7 +402,7 @@
    "outputs": [],
    "source": [
     "# Handle US Virgin Islands\n",
-    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv'\n",
     "PHASE1_FILE = \"../../countries_regions_phase1_fix.csv\"\n",
     "latest_df = load_dataset(LATEST_DATA_URL, PHASE1_FILE)\n",
     "latest_df = phase1_update(latest_df)"

--- a/predictor_submission_template.ipynb
+++ b/predictor_submission_template.ipynb
@@ -74,7 +74,7 @@
    "metadata": {},
    "source": [
     "## Data\n",
-    "The university of Oxford Blavatnik School of Government is [tracking coronavirus government responses](https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker). They have assembled a [data set](https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv) containing historical data since January 1st, 2020 for the number of cases and IPs for most countries in the world."
+    "The university of Oxford Blavatnik School of Government is [tracking coronavirus government responses](https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker). They have assembled a [data set](https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv) containing historical data since January 1st, 2020 for the number of cases and IPs for most countries in the world."
    ]
   },
   {
@@ -92,7 +92,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv'\n",
     "df = pd.read_csv(DATA_URL,\n",
     "                 parse_dates=['Date'],\n",
     "                 encoding=\"ISO-8859-1\",\n",

--- a/prescriptor_robojudge.ipynb
+++ b/prescriptor_robojudge.ipynb
@@ -74,7 +74,7 @@
     "from covid_xprize.scoring.predictor_scoring import load_dataset\n",
     "from covid_xprize.validation.scenario_generator import generate_scenario\n",
     "\n",
-    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv'\n",
+    "LATEST_DATA_URL = 'https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv'\n",
     "GEO_FILE = \"countries_regions.csv\"\n",
     "\n",
     "latest_df = load_dataset(LATEST_DATA_URL, GEO_FILE)"

--- a/resources.md
+++ b/resources.md
@@ -16,7 +16,7 @@ From Prediction to Prescription: Evolutionary Optimization of Non-Pharmaceutical
 ## Blavatnik School of Government / University of Oxford 
 1. Main page: [Coronavirus Government Response Tracker](https://www.bsg.ox.ac.uk/research/research-projects/coronavirus-government-response-tracker)
 1. Intervention plans: [Codebook for the Oxford Covid-19 Government Response Tracker](https://github.com/OxCGRT/covid-policy-tracker/blob/master/documentation/codebook.md)
-1. Intervention plans data: [OxCGRT_latest.csv](https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv)
+1. Intervention plans data: [OxCGRT_latest.csv](https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv)
 1. Anna Petherick, Beatriz Kira, Thomas Hale, Toby Phillips, Samuel Webster, Emily Cameron-Blake, Laura Hallas, Saptarshi Majumdar, Helen Tatlow  
 Variation in government responses to covid-19  
 [BSG-WP-2020/032](https://www.bsg.ox.ac.uk/research/publications/variation-government-responses-covid-19)


### PR DESCRIPTION
Updated the dataset URL:
from: https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv
to: https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker-legacy/main/legacy_data_202207/OxCGRT_latest.csv
