### PR TITLE
Use correct repo owner after repo move

### DIFF
--- a/codefresh.yml
+++ b/codefresh.yml
@@ -11,7 +11,7 @@ steps:
   clone_main_repo:
     type: git-clone
     title: "Clone repo"
-    repo: leaf-ai/covid-xprize
+    repo: cognizant-ai-labs/covid-xprize
     revision: '${{CF_REVISION}}'
     git: github
 


### PR DESCRIPTION
This PR gets us up to the Docker build step, which fails with
ERROR: No matching distribution found for pandas==1.5.3 

But the issue regarding the unavailable repo is corrected.

I did two things:
Changed the codefresh yaml to point to the correct repo owner.
Set up another Github Integration within CF which can access the repos owned by cognizant-ai-labs. This allows us to find the repo in the list when creating a trigger. I modified the pipeline trigger to point at the correct place.