### PR TITLE
Make keras version in setup.py match requirements.txt, and tensorflow version"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import os
 import sys
 from setuptools import setup, find_packages
 
-LIBRARY_VERSION = '2.0.0'
+LIBRARY_VERSION = '2.0.1'
 
 CURRENT_PYTHON = sys.version_info[:2]
 REQUIRED_PYTHON = (3, 10)
@@ -60,7 +60,7 @@ setup(
         ]
     },
     install_requires=[
-        'keras==2.12.0',
+        'keras==2.11.0',
         'neat-python==0.92',
         'numpy==1.24.2',
         'pandas==1.5.3',


### PR DESCRIPTION
Ran into issues installing `2.0.0` in another repo. The Keras version didn't match the TensorFlow one in `setup.py`. Error was:

```
The conflict is caused by:
    covid-xprize 2.0.0 depends on keras==2.12.0
    tensorflow 2.11.1 depends on keras<2.12 and >=2.11.0
```
